### PR TITLE
Speed up build times for users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ RUN apt-get install -y gcc g++ make
 RUN node --version
 RUN npm --version
 
-# copy files 
+# copy dependency files
 RUN mkdir src
 WORKDIR src/
-COPY . .
+COPY requirements.txt .
 
 # instsall Jupyter, domaincat requirements, and widget extensions
 RUN pip3 install -r requirements.txt
@@ -26,6 +26,9 @@ RUN jupyter labextension install plotlywidget@4.14.3 --no-build
 RUN jupyter lab build
 RUN npm cache clean --force
 RUN unset NODE_OPTIONS
+
+# Rest of Files copied
+COPY . .
 
 # Run jupyter lab
 CMD ["jupyter", "lab", "--port=9999", "--no-browser", "--ip=0.0.0.0", "--allow-root"]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Build the jupyter notebook container
 
 Run the jupyter notebook
 
-`$ docker run -p 9999:9999 --name domaincat domaincat`
+`$ docker run -p 9999:9999 -v $(PWD)/data:/src/data --name domaincat domaincat`
+
+Mounting the data directory as a volume allows you to add new files to the container without having to rebuild it.
 
 ## Installation Steps: Manual (cross your fingers)
 


### PR DESCRIPTION
Speed up build times and add instructions so that users can add data files without rebuilding.

Some changes were made to the Dockerfile so that the ordering follows best practices for building docker images. It should save a bunch of time for users that want to make changes to the python files as jupyterlab setup seems to be the majority of build time.

See this link for reference: https://pythonspeed.com/articles/docker-caching-model/

Also added the suggestion docker run command to include mounting the data directory. This would allow users to add files to the data directory and appear in the docker instance without having to rebuild the image.